### PR TITLE
Updated info about PATCH requests

### DIFF
--- a/rest/README.md
+++ b/rest/README.md
@@ -49,7 +49,7 @@ PUT /addresses/1
 
 ### PATCH
 
-Update only the specified fields of an entity at a URI. A PATCH request is idempotent. Idempotency is the main difference between the expectations of PUT versus a POST request.
+Update only the specified fields of an entity at a URI. A PATCH request is not necessarily idempotent.
 
 ```
 PATCH /addresses/1


### PR DESCRIPTION
Based on the description provided by the [RFC 5789 specification](https://tools.ietf.org/html/rfc5789),
I believe that `PATCH` requests are not necessarily idempotent (in the same vein as `POST` requests).

I'm quoting the specific lines from that document for reference:

>    PATCH is neither safe nor idempotent as defined by [RFC2616], Section
>    9.1.
> 
>    A PATCH request can be issued in such a way as to be idempotent,