### PR TITLE
URL Cleanup

### DIFF
--- a/amqp/README.md
+++ b/amqp/README.md
@@ -23,12 +23,12 @@ These advantages and the openness of the spec have inspired the creation of mult
 - JMS and AMQP both have brokers responsible for receiving, routing, and ultimately dispensing messages to consumers.
 - AMQP has exchanges, routes, and queues. Messages are first published to exchanges. Routes define on which queue(s) to pipe the message. Consumers subscribing to that queue then receive a copy of the message. If more than one consumer subscribes to the same queue, the messages are dispensed in a round-robin fashion.
 
-[amqp]: http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol
-[jms]: http://en.wikipedia.org/wiki/Java_Message_Service
-[amqp-spec]: http://www.amqp.org/resources/download
-[pivotal]: http://gopivotal.com
-[rabbitmq]: http://rabbitmq.com
-[activemq]: http://activemq.apache.org/
-[qpid]: http://qpid.apache.org/index.html
-[solace]: http://dev.solace.com/tech/amqp/
+[amqp]: https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol
+[jms]: https://en.wikipedia.org/wiki/Java_Message_Service
+[amqp-spec]: https://www.amqp.org/resources/download
+[pivotal]: https://pivotal.io
+[rabbitmq]: https://rabbitmq.com
+[activemq]: https://activemq.apache.org/
+[qpid]: https://qpid.apache.org/index.html
+[solace]: https://dev.solace.com/tech/amqp/
 

--- a/application-context/README.md
+++ b/application-context/README.md
@@ -59,6 +59,6 @@ public class Application {
 
 In the code above, there are two arguments to the bean definition: `RedisConnectionFactory` and `MessageListenerAdapter`. The method expresses its needs and Spring's DI container will supply them assuming they are available. While it's possible to fetch these beans directly the an instance of `ApplicationContext`, such a solution leans too heavily on container APIs and is not necessary.
 
-[`ApplicationContext`]: http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html
-[`ApplicationContextAware`]: http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContextAware.html
-[`@Autowired`]: http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html
+[`ApplicationContext`]: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html
+[`ApplicationContextAware`]: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContextAware.html
+[`@Autowired`]: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html

--- a/cors/README.md
+++ b/cors/README.md
@@ -23,11 +23,11 @@ For example, suppose that client code served from foo.client.com were to send th
 GET /greeting/ HTTP/1.1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/536.30.1 (KHTML, like Gecko) Version/6.0.5 Safari/536.30.1
 Accept: application/json, text/plain, */*
-Referer: http://foo.client.com/
-Origin: http://foo.client.com
+Referer: https://foo.client.com/
+Origin: https://foo.client.com/
 ```
 
-The `Origin` header tells the server that the client code originated from http://foo.client.com.
+The `Origin` header tells the server that the client code originated from https://foo.client.com/.
 So it checks its same-origin policies and determines that it can serve the request.
 The response might look like this:
 
@@ -38,12 +38,12 @@ Date: Wed, 20 Nov 2013 19:36:00 GMT
 Server: Apache-Coyote/1.1
 Content-Length: 35
 Connection: keep-alive
-Access-Control-Allow-Origin: http://foo.client.com
+Access-Control-Allow-Origin: https://foo.client.com/
 
 [response payload]
 ```
 
-The `Access-Control-Allow-Origin` indicates that "http://foo.client.com" is allowed access, but no other origins will be allowed access.
+The `Access-Control-Allow-Origin` indicates that "https://foo.client.com/" is allowed access, but no other origins will be allowed access.
 
 Optionally, `Access-Control-Allow-Origin` may be set to "*" to indicate that all client origins are allowed. This is considered an unsafe practice, however, except in special cases where an API is completely public and is expected to be consumed by any client.
 
@@ -61,7 +61,7 @@ OPTIONS /resource/12345
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/536.30.1 (KHTML, like Gecko) Version/6.0.5 Safari/536.30.1
 Access-Control-Request-Method: DELETE
 Access-Control-Request-Headers: origin, x-requested-with, accept
-Origin: http://foo.client.com
+Origin: https://foo.client.com/
 ```
 
 The preflight request is essentially asking the server if it would allow the DELETE request, without actually sending the DELETE request.
@@ -73,7 +73,7 @@ Date: Wed, 20 Nov 2013 19:36:00 GMT
 Server: Apache-Coyote/1.1
 Content-Length: 0
 Connection: keep-alive
-Access-Control-Allow-Origin: http://foo.client.com
+Access-Control-Allow-Origin: https://foo.client.com/
 Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
 Access-Control-Max-Age: 86400
 ```
@@ -83,5 +83,5 @@ The `Access-Control-Max-Age` indicates that this preflight response is good for 
 
 In the meantime, the client will be allowed to send the original DELETE request for the resource.
 
-[same-origin-policy]: http://www.w3.org/Security/wiki/Same_Origin_Policy
+[same-origin-policy]: https://www.w3.org/Security/wiki/Same_Origin_Policy
 [cors]: http://www.w3.org/TR/cors/

--- a/git/README.md
+++ b/git/README.md
@@ -2,13 +2,13 @@
 
 [Git][git] is a free and open source distributed version control system (DVCS). It is designed to handle projects of any size and scope with speed and efficiency.
 
-Git was invented by [Linux](http://www.linux.org/) creator [Linus Torvalds](http://en.wikipedia.org/wiki/Linus_Torvalds) to support the huge, disparate group of Linux developers. But Git's popularity is more closely tied to http://github.com. Git has been in existence for years, but did not gain wide acceptance beyond the Linux community until the more recent surge in GitHub popularity. GitHub allows you to host open source projects at no cost. It also provides simple hooks and a friendly user experience that make Git easier to use.
+Git was invented by [Linux](https://www.linux.org/) creator [Linus Torvalds](https://en.wikipedia.org/wiki/Linus_Torvalds) to support the huge, disparate group of Linux developers. But Git's popularity is more closely tied to https://github.com. Git has been in existence for years, but did not gain wide acceptance beyond the Linux community until the more recent surge in GitHub popularity. GitHub allows you to host open source projects at no cost. It also provides simple hooks and a friendly user experience that make Git easier to use.
 
 Other projects such as [Mac Homebrew](https://github.com/mxcl/homebrew/wiki/Formula-Cookbook#creating-the-diff) have invested deeply in Git. Homebrew lets you install open source packages on a Mac. The tools to build and manage these formulas leverage Git for diff tools, crafting patches, management of resources, and submitting new and updated packages through [pull requests](https://help.github.com/articles/using-pull-requests).
 
 ### Git vs. other DVCSes
 
-The two other most popular DVCS choices are [Mercurial](http://mercurial.selenic.com/) and [Bazaar](http://bazaar.canonical.com/en/). Mercurial has the command line tool `hg` (named after the chemical symbol for mercury), and Bazaar's command line tool is `bzr`.
+The two other most popular DVCS choices are [Mercurial](https://mercurial.selenic.com/) and [Bazaar](https://bazaar.canonical.com/en/). Mercurial has the command line tool `hg` (named after the chemical symbol for mercury), and Bazaar's command line tool is `bzr`.
 
 Mercurial is associated with many open source projects. Canonical, the company behind Ubuntu Linux, uses Bazaar. It is not unusual for a developer to need familiarity with Git, Mercurial, and Bazaar.
 
@@ -37,5 +37,5 @@ To illustrate the difference between DVCS and non-DVCS SCM systems, consider how
 
 The built-in advantage of tools like Git is that every person with a copy has _everything_ needed to reconstitute a project. If a central server crashes and all data is lost, any remote copy can be designated the official copy, because it will have enough information to proceed. The only discrepancy arises if developers don't have the latest commits.
 
-[git]: http://gitscm.com/ 
+[git]: https://git-scm.com 
 

--- a/hadoop/README.md
+++ b/hadoop/README.md
@@ -1,6 +1,6 @@
 # Understanding Hadoop
 
-[Apache™ Hadoop®](http://hadoop.apache.org/) is an open-source project that provides reliable, scalable, distributed computing.
+[Apache™ Hadoop®](https://hadoop.apache.org/) is an open-source project that provides reliable, scalable, distributed computing.
 
 The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models. It can scale up from single servers to thousands of machines, each offering local computation and storage. Rather than relying on hardware to deliver high-availability, the library itself detects and handles failures at the application layer. It delivers a highly-available service on top of a cluster of computers, each of which may be prone to failure.
 
@@ -11,11 +11,11 @@ Hadoop supports multiple programming models including:
 
 ### Hive, Pig, and other Hadoop-based systems
 
-[Hive is a data warehouse system](http://hive.apache.org/) that provides the means to query Hadoop file systems with a SQL-like language called HiveQL.
+[Hive is a data warehouse system](https://hive.apache.org/) that provides the means to query Hadoop file systems with a SQL-like language called HiveQL.
 
-[Apache Pig](http://pig.apache.org/) is a platform for analyzing large sets of data using map-reduce programs. The name is based on its query/map-reduce language, Pig Latin.
+[Apache Pig](https://pig.apache.org/) is a platform for analyzing large sets of data using map-reduce programs. The name is based on its query/map-reduce language, Pig Latin.
 
-Many other systems are being built on top of Hadoop. It is being used as a distributed, fault tolerant infrastructure. Examples include [Cassandra NoSQL database](http://cassandra.apache.org/), and [HBase](http://hbase.apache.org/).
+Many other systems are being built on top of Hadoop. It is being used as a distributed, fault tolerant infrastructure. Examples include [Cassandra NoSQL database](https://cassandra.apache.org/), and [HBase](https://hbase.apache.org/).
 
 ## Challenges
 

--- a/hateoas/README.md
+++ b/hateoas/README.md
@@ -1,6 +1,6 @@
 # Understanding HATEOAS
 
-HATEOAS (Hypermedia as the Engine of Application State) is a [constraint of the REST application architecture](http://en.wikipedia.org/wiki/HATEOAS).
+HATEOAS (Hypermedia as the Engine of Application State) is a [constraint of the REST application architecture](https://en.wikipedia.org/wiki/HATEOAS).
 
 A hypermedia-driven site provides information to navigate the site's [REST][u-rest] interfaces dynamically by including hypermedia links with the responses. This capability differs from that of SOA-based systems and WSDL-driven interfaces. With SOA, servers and clients usually must access a fixed specification that might be staged somewhere else on the website, on another website, or perhaps distributed by email.
 
@@ -80,6 +80,6 @@ Look at the following catalog, courtesy of the sample application shown in the [
     } ]
 }   
 ```
-Not only are the items and their prices shown, but the URL for each resource is shown, providing clear information on how to access these resources. According to the [Richardson Maturity Model](http://martinfowler.com/articles/richardsonMaturityModel.html), HATEOAS is considered the final level of REST. This means that each link is presumed to implement the standard REST verbs of GET, POST, PUT, and DELETE (or a subset). Thus providing the links as shown above gives the client the information they need to navigate the service.
+Not only are the items and their prices shown, but the URL for each resource is shown, providing clear information on how to access these resources. According to the [Richardson Maturity Model](https://martinfowler.com/articles/richardsonMaturityModel.html), HATEOAS is considered the final level of REST. This means that each link is presumed to implement the standard REST verbs of GET, POST, PUT, and DELETE (or a subset). Thus providing the links as shown above gives the client the information they need to navigate the service.
 
 [u-rest]: /understanding/rest

--- a/javascript-package-managers/README.md
+++ b/javascript-package-managers/README.md
@@ -1,8 +1,8 @@
 # Understanding JavaScript Package Managers
 
-There are several JavaScript package managers: [npm](http://npmjs.org/),
-[bower](http://bower.io/), [volo](http://volojs.org/),
-[ringojs](http://packages.ringojs.org/), [component](http://component.io/).
+There are several JavaScript package managers: [npm](https://npmjs.org/),
+[bower](https://bower.io/), [volo](https://volojs.org/),
+[ringojs](http://packages.ringojs.org/), [component](https://component.io/).
 Currently, npm and bower have the most registered packages and enjoy the
 broadest third-party support.
 

--- a/javascript-promises/README.md
+++ b/javascript-promises/README.md
@@ -16,7 +16,7 @@ A promise can be in one of 3 states:
 
 When a promise is pending, it can transition to the fulfilled or rejected state.  Once a promise is fulfilled or rejected, however, it will never transition to any other state, and its value or failure reason will not change.
 
-Promises have been implemented in many languages, and while promise APIs differ from language to language, JavaScript promises have converged to the [Promises/A+](http://promisesaplus.com) proposed standard.  EcmaScript 6 is slated to provide promises as a first-class language feature, and they will be based on the Promises/A+ proposal.
+Promises have been implemented in many languages, and while promise APIs differ from language to language, JavaScript promises have converged to the [Promises/A+](https://promisesaplus.com) proposed standard.  EcmaScript 6 is slated to provide promises as a first-class language feature, and they will be based on the Promises/A+ proposal.
 
 ## Using Promises
 

--- a/nosql/README.md
+++ b/nosql/README.md
@@ -37,16 +37,16 @@ Because each NoSQL data store has unique aspects in both how its data is stored 
 
 Dozens of NoSQL data stores are available; the following are among the most popular:
 
-- [MongoDB](http://www.mongodb.org/). Open-source document database.
-- [CouchDB](http://couchdb.apache.org/). Database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API.
-- [GemFire](http://www.springsource.org/spring-gemfire). Distributed data management platform providing dynamic scalability, high performance, and database-like persistence.
-- [Redis](http://redis.io/). Data structure server wherein keys can contain strings, hashes, lists, sets, and sorted sets.
-- [Cassandra](http://cassandra.apache.org/). Database that provides scalability and high availability without compromising performance.
-- [memcached](http://memcached.org/). Open source high-performance, distributed-memory, and object-caching system.
-- [Hazelcast](http://www.hazelcast.com/). Open source highly scalable data distribution platform.
-- [HBase](http://hbase.apache.org/). Hadoop database, a distributed and scalable big data store.
-- [Mnesia](http://www.erlang.org/doc/man/mnesia.html). Distributed database management system that exhibits soft real-time properties.
-- [Neo4j](http://www.neo4j.org/). Open source high-performance, enterprise-grade graph database.
+- [MongoDB](https://www.mongodb.org/). Open-source document database.
+- [CouchDB](https://couchdb.apache.org/). Database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API.
+- [GemFire](https://www.springsource.org/spring-gemfire). Distributed data management platform providing dynamic scalability, high performance, and database-like persistence.
+- [Redis](https://redis.io/). Data structure server wherein keys can contain strings, hashes, lists, sets, and sorted sets.
+- [Cassandra](https://cassandra.apache.org/). Database that provides scalability and high availability without compromising performance.
+- [memcached](https://memcached.org/). Open source high-performance, distributed-memory, and object-caching system.
+- [Hazelcast](https://www.hazelcast.com/). Open source highly scalable data distribution platform.
+- [HBase](https://hbase.apache.org/). Hadoop database, a distributed and scalable big data store.
+- [Mnesia](https://www.erlang.org/doc/man/mnesia.html). Distributed database management system that exhibits soft real-time properties.
+- [Neo4j](https://www.neo4j.org/). Open source high-performance, enterprise-grade graph database.
 
 
 [eventual-consistency]: https://en.wikipedia.org/wiki/Eventual_consistency

--- a/nosql/SIDEBAR.md
+++ b/nosql/SIDEBAR.md
@@ -21,17 +21,17 @@ There's more to NoSQL than what is presented here. You may want to continue your
 
 Here are links to Spring's NoSQL projects:
 
-- [Spring Data JDBC Extensions](http://www.springsource.org/spring-data/jdbc-extensions)
-- [Spring for Apache Hadoop](http://www.springsource.org/spring-data/hadoop)
-- [Spring Data GemFire](http://www.springsource.org/spring-gemfire)
-- [Spring Data Redis](http://www.springsource.org/spring-data/redis)
-- [Spring Data MongoDB](http://www.springsource.org/spring-data/mongodb)
-- [Spring Data Neo4j](http://www.springsource.org/spring-data/neo4j)
+- [Spring Data JDBC Extensions](https://www.springsource.org/spring-data/jdbc-extensions)
+- [Spring for Apache Hadoop](https://www.springsource.org/spring-data/hadoop)
+- [Spring Data GemFire](https://www.springsource.org/spring-gemfire)
+- [Spring Data Redis](https://www.springsource.org/spring-data/redis)
+- [Spring Data MongoDB](https://www.springsource.org/spring-data/mongodb)
+- [Spring Data Neo4j](https://www.springsource.org/spring-data/neo4j)
 - [Spring Data Solr](https://github.com/SpringSource/spring-data-solr)
 - [Spring Data Elasticsearch](https://github.com/BioMedCentralLtd/spring-data-elasticsearch)
 - [Spring Data Couchbase](https://github.com/couchbaselabs/spring-data-couchbase)
 - [Spring Data FuzzyDB](https://github.com/whirlwind-match/fuzzydb-spring/)
 
-Each of these projects provides a simplified API to interact with their relevant data stores. They also employ a commonly shared [Spring Data Commons](http://www.springsource.org/spring-data/commons) to make it possible to write basic **save()**, **delete()**, **update()**, and **findXxxYyyZzz()** methods which automatically generate queries. This can provide a developer with a lot of data needs.
+Each of these projects provides a simplified API to interact with their relevant data stores. They also employ a commonly shared [Spring Data Commons](https://www.springsource.org/spring-data/commons) to make it possible to write basic **save()**, **delete()**, **update()**, and **findXxxYyyZzz()** methods which automatically generate queries. This can provide a developer with a lot of data needs.
 
 When a more customized query is needed, `@Query("<query string>")` can be used to annotate the method, allowing the developer to write a query in the data store's query language.

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,6 +1,6 @@
 # Understanding OAuth
 
-OAuth (Open Authorization), as stated on [oauth.net](http://oauth.net), is "an open protocol to allow secure authorization in a simple and standard method from web, mobile and desktop applications." In other words, OAuth is an authorization protocol that allows users to approve a third-party application to act on their behalf without revealing their login credentials to that third party. 
+OAuth (Open Authorization), as stated on [oauth.net](https://oauth.net), is "an open protocol to allow secure authorization in a simple and standard method from web, mobile and desktop applications." In other words, OAuth is an authorization protocol that allows users to approve a third-party application to act on their behalf without revealing their login credentials to that third party. 
 
 In contrast, OAuth is not an authentication protocol for signing in with a username and password. Authentication is handled independently from the OAuth process. 
 
@@ -32,7 +32,7 @@ The next version of OAuth is not backwards compatible with previous versions. OA
 
 #### Authorization grants
 
-The [RFC 6749](http://tools.ietf.org/html/rfc6749#section-1.3) specification defines four grant types. These grant types provide developers with alternative methods for obtaining the user's permission to access the resources on a provider. 
+The [RFC 6749](https://tools.ietf.org/html/rfc6749#section-1.3) specification defines four grant types. These grant types provide developers with alternative methods for obtaining the user's permission to access the resources on a provider. 
 
  - Authorization Code Grant. The authorization code is obtained by using an authorization server as an intermediary between the client and resource owner.
  - Implicit grant. This grant is a simplified authorization code flow optimized

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -16,4 +16,4 @@ You can activate a profile at runtime by setting `spring.profiles.active` (a com
 
 By default Spring always runs in the "default" profile, but there are no other special profiles defined by Spring. Cloud Foundry runs a Spring application in the "cloud" profile.
 
-[`@Profile`]: http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html
+[`@Profile`]: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html

--- a/rest/README.md
+++ b/rest/README.md
@@ -1,6 +1,6 @@
 # Understanding REST
 
-REST (Representational State Transfer) was introduced and defined in 2000 by Roy Fielding in his [doctoral dissertation](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm). REST is an architectural style for designing distributed systems. It is not a standard but a set of constraints, such as being stateless, having a client/server relationship, and a uniform interface. REST is not strictly related to HTTP, but it is most commonly associated with it.
+REST (Representational State Transfer) was introduced and defined in 2000 by Roy Fielding in his [doctoral dissertation](https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm). REST is an architectural style for designing distributed systems. It is not a standard but a set of constraints, such as being stateless, having a client/server relationship, and a uniform interface. REST is not strictly related to HTTP, but it is most commonly associated with it.
 
 ## Principles of REST
 
@@ -17,7 +17,7 @@ Use HTTP methods to map CRUD (create, retrieve, update, delete) operations to HT
 
 ### GET
 
-Retrieve information. GET requests must be safe and [idempotent](http://en.wikipedia.org/wiki/Idempotence#Computer_science_meaning), meaning regardless of how many times it repeats with the same parameters, the results are the same. They can have side effects, but the user doesn't expect them, so they cannot be critical to the operation of the system. Requests can also be partial or conditional.
+Retrieve information. GET requests must be safe and [idempotent](https://en.wikipedia.org/wiki/Idempotence#Computer_science_meaning), meaning regardless of how many times it repeats with the same parameters, the results are the same. They can have side effects, but the user doesn't expect them, so they cannot be critical to the operation of the system. Requests can also be partial or conditional.
 
 Retrieve an address with an ID of 1:
 

--- a/soap/README.md
+++ b/soap/README.md
@@ -2,6 +2,6 @@
 
 **SOAP** or **Simple Object Access Protocol** is a protocol designed to exchange information in the form of Web Services. It is primarily based on XML documents exchanged over HTTP, but it's possible to transmit messages through other mediums like email and JMS.
 
-SOAP was initially designed in 1998 during the height of [CORBA](http://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture) to provide a simpler way to transfer information. Since then, multiple versions of the SOAP spec have been released.
+SOAP was initially designed in 1998 during the height of [CORBA](https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture) to provide a simpler way to transfer information. Since then, multiple versions of the SOAP spec have been released.
 
-SOAP web services are generally based on a a [Web Services Description Language](http://en.wikipedia.org/wiki/Web_Services_Description_Language) or WSDL, which is an XML contract that defines all the data and services offered by a given web service. The client and the server both use this contract as a basis for exchanging information and making [remote procedural calls](http://en.wikipedia.org/wiki/Remote_procedure_call).
+SOAP web services are generally based on a a [Web Services Description Language](https://en.wikipedia.org/wiki/Web_Services_Description_Language) or WSDL, which is an XML contract that defines all the data and services offered by a given web service. The client and the server both use this contract as a basis for exchanging information and making [remote procedural calls](https://en.wikipedia.org/wiki/Remote_procedure_call).

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -1,8 +1,8 @@
 # Understanding Tomcat
 
-[Tomcat](http://tomcat.apache.org/) is an open source software implementation of the Java Servlet and JavaServer Pages (JSPs) technologies. Tomcat is flexible in that it allows third-party [view technologies][u-view-templates], hence it does not restrict you to JSPs.
+[Tomcat](https://tomcat.apache.org/) is an open source software implementation of the Java Servlet and JavaServer Pages (JSPs) technologies. Tomcat is flexible in that it allows third-party [view technologies][u-view-templates], hence it does not restrict you to JSPs.
 
-Tomcat is developed in an open and participatory environment that is governed by the [Apache Software Foundation](http://www.apache.org/). It is released under the [Apache License version 2](http://www.apache.org/licenses/LICENSE-2.0). 
+Tomcat is developed in an open and participatory environment that is governed by the [Apache Software Foundation](https://www.apache.org/). It is released under the [Apache License version 2](http://www.apache.org/licenses/LICENSE-2.0). 
 
 Tomcat powers numerous large-scale, mission-critical web applications across a diverse range of industries and organizations.
 

--- a/view-templates/README.md
+++ b/view-templates/README.md
@@ -8,20 +8,20 @@ Within an application, the view layer may use one or more different technologies
 
 The following view template libraries, among others, are compatible with Spring:
 
- - [JSP/JSTL](http://www.oracle.com/technetwork/java/javaee/jsp/index.html)
- - [Thymeleaf](http://www.thymeleaf.org/)
- - [Tiles](http://tiles.apache.org/)
- - [Freemarker](http://freemarker.org/)
+ - [JSP/JSTL](https://www.oracle.com/technetwork/java/javaee/jsp/index.html)
+ - [Thymeleaf](https://www.thymeleaf.org/)
+ - [Tiles](https://tiles.apache.org/)
+ - [Freemarker](https://freemarker.apache.org/)
  - [Velocity](https://velocity.apache.org/)
 
 
 ## Comparing JSP and Thymeleaf
 
-The following examples illustrate how to render the same content with JSP and Thymeleaf templates. For more detail, see this [Spring blog post](http://blog.springsource.org/2013/03/26/bringing-new-life-to-spring-travel-with-thymeleaf/).
+The following examples illustrate how to render the same content with JSP and Thymeleaf templates. For more detail, see this [Spring blog post](https://blog.springsource.org/2013/03/26/bringing-new-life-to-spring-travel-with-thymeleaf/).
 
 ### JSP
 
-Note the [JSTL](http://en.wikipedia.org/wiki/JavaServer_Pages_Standard_Tag_Library) (JavaServer Pages Standard Tag Library) expressions in this example.
+Note the [JSTL](https://en.wikipedia.org/wiki/JavaServer_Pages_Standard_Tag_Library) (JavaServer Pages Standard Tag Library) expressions in this example.
 
 ```html
 <c:url var="hotelsUrl" value="/hotels"/>

--- a/war/README.md
+++ b/war/README.md
@@ -8,5 +8,5 @@ WAR files are usually deployed in servlet containers, but can also be deployed t
 
 WAR files cannot be edited while the application is running. Any changes require rebuilding the file.
 
-[war]: http://en.wikipedia.org/wiki/WAR_file_format_(Sun)
+[war]: https://en.wikipedia.org/wiki/WAR_file_format_(Sun)
 [u-jsp]: /understanding/view-templates


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://olivergierke.de/2013/11/why-field-injection-is-evil/ (200) with 1 occurrences could not be migrated:  
   ([https](https://olivergierke.de/2013/11/why-field-injection-is-evil/) result SSLHandshakeException).
* [ ] http://packages.ringojs.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://packages.ringojs.org/) result SSLHandshakeException).
* [ ] http://wiki.commonjs.org/wiki/Modules/1.1.1 (200) with 1 occurrences could not be migrated:  
   ([https](https://wiki.commonjs.org/wiki/Modules/1.1.1) result SSLHandshakeException).
* [ ] http://www.w3.org/TR/cors/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.w3.org/TR/cors/) result SSLException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://freemarker.org/ (301) with 1 occurrences migrated to:  
  https://freemarker.apache.org/ ([https](https://freemarker.org/) result ConnectTimeoutException).
* [ ] http://volojs.org/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://volojs.org/ ([https](https://volojs.org/) result ConnectTimeoutException).
* [ ] http://www.w3.org/Security/wiki/Same_Origin_Policy (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/Security/wiki/Same_Origin_Policy ([https](https://www.w3.org/Security/wiki/Same_Origin_Policy) result SSLException).
* [ ] http://foo.client.com/ (301) with 1 occurrences migrated to:  
  https://foo.client.com/ ([https](https://foo.client.com/) result 404).
* [ ] http://foo.client.com (301) with 6 occurrences migrated to:  
  https://foo.client.com/ ([https](https://foo.client.com) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://activemq.apache.org/ with 1 occurrences migrated to:  
  https://activemq.apache.org/ ([https](https://activemq.apache.org/) result 200).
* [ ] http://bazaar.canonical.com/en/ with 1 occurrences migrated to:  
  https://bazaar.canonical.com/en/ ([https](https://bazaar.canonical.com/en/) result 200).
* [ ] http://bower.io/ with 1 occurrences migrated to:  
  https://bower.io/ ([https](https://bower.io/) result 200).
* [ ] http://cassandra.apache.org/ with 2 occurrences migrated to:  
  https://cassandra.apache.org/ ([https](https://cassandra.apache.org/) result 200).
* [ ] http://couchdb.apache.org/ with 1 occurrences migrated to:  
  https://couchdb.apache.org/ ([https](https://couchdb.apache.org/) result 200).
* [ ] http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol ([https](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) result 200).
* [ ] http://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture ([https](https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture) result 200).
* [ ] http://en.wikipedia.org/wiki/HATEOAS with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HATEOAS ([https](https://en.wikipedia.org/wiki/HATEOAS) result 200).
* [ ] http://en.wikipedia.org/wiki/Idempotence with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Idempotence ([https](https://en.wikipedia.org/wiki/Idempotence) result 200).
* [ ] http://en.wikipedia.org/wiki/JavaServer_Pages_Standard_Tag_Library with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/JavaServer_Pages_Standard_Tag_Library ([https](https://en.wikipedia.org/wiki/JavaServer_Pages_Standard_Tag_Library) result 200).
* [ ] http://en.wikipedia.org/wiki/Java_Message_Service with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Java_Message_Service ([https](https://en.wikipedia.org/wiki/Java_Message_Service) result 200).
* [ ] http://en.wikipedia.org/wiki/Linus_Torvalds with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Linus_Torvalds ([https](https://en.wikipedia.org/wiki/Linus_Torvalds) result 200).
* [ ] http://en.wikipedia.org/wiki/Remote_procedure_call with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Remote_procedure_call ([https](https://en.wikipedia.org/wiki/Remote_procedure_call) result 200).
* [ ] http://en.wikipedia.org/wiki/Web_Services_Description_Language with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Web_Services_Description_Language ([https](https://en.wikipedia.org/wiki/Web_Services_Description_Language) result 200).
* [ ] http://gitscm.com/ (302) with 1 occurrences migrated to:  
  https://git-scm.com ([https](https://gitscm.com/) result 200).
* [ ] http://github.com with 1 occurrences migrated to:  
  https://github.com ([https](https://github.com) result 200).
* [ ] http://hadoop.apache.org/ with 1 occurrences migrated to:  
  https://hadoop.apache.org/ ([https](https://hadoop.apache.org/) result 200).
* [ ] http://hbase.apache.org/ with 2 occurrences migrated to:  
  https://hbase.apache.org/ ([https](https://hbase.apache.org/) result 200).
* [ ] http://hive.apache.org/ with 1 occurrences migrated to:  
  https://hive.apache.org/ ([https](https://hive.apache.org/) result 200).
* [ ] http://martinfowler.com/articles/richardsonMaturityModel.html with 1 occurrences migrated to:  
  https://martinfowler.com/articles/richardsonMaturityModel.html ([https](https://martinfowler.com/articles/richardsonMaturityModel.html) result 200).
* [ ] http://memcached.org/ with 1 occurrences migrated to:  
  https://memcached.org/ ([https](https://memcached.org/) result 200).
* [ ] http://oauth.net with 1 occurrences migrated to:  
  https://oauth.net ([https](https://oauth.net) result 200).
* [ ] http://pig.apache.org/ with 1 occurrences migrated to:  
  https://pig.apache.org/ ([https](https://pig.apache.org/) result 200).
* [ ] http://gopivotal.com (302) with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://gopivotal.com) result 200).
* [ ] http://promisesaplus.com with 1 occurrences migrated to:  
  https://promisesaplus.com ([https](https://promisesaplus.com) result 200).
* [ ] http://qpid.apache.org/index.html with 1 occurrences migrated to:  
  https://qpid.apache.org/index.html ([https](https://qpid.apache.org/index.html) result 200).
* [ ] http://redis.io/ with 1 occurrences migrated to:  
  https://redis.io/ ([https](https://redis.io/) result 200).
* [ ] http://tiles.apache.org/ with 1 occurrences migrated to:  
  https://tiles.apache.org/ ([https](https://tiles.apache.org/) result 200).
* [ ] http://tomcat.apache.org/ with 1 occurrences migrated to:  
  https://tomcat.apache.org/ ([https](https://tomcat.apache.org/) result 200).
* [ ] http://tools.ietf.org/html/rfc6749 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6749 ([https](https://tools.ietf.org/html/rfc6749) result 200).
* [ ] http://www.amqp.org/resources/download with 1 occurrences migrated to:  
  https://www.amqp.org/resources/download ([https](https://www.amqp.org/resources/download) result 200).
* [ ] http://www.apache.org/ with 1 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* [ ] http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm with 1 occurrences migrated to:  
  https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm ([https](https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm) result 200).
* [ ] http://www.linux.org/ with 1 occurrences migrated to:  
  https://www.linux.org/ ([https](https://www.linux.org/) result 200).
* [ ] http://www.oracle.com/technetwork/java/javaee/jsp/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javaee/jsp/index.html ([https](https://www.oracle.com/technetwork/java/javaee/jsp/index.html) result 200).
* [ ] http://www.thymeleaf.org/ with 1 occurrences migrated to:  
  https://www.thymeleaf.org/ ([https](https://www.thymeleaf.org/) result 200).
* [ ] http://blog.springsource.org/2013/03/26/bringing-new-life-to-spring-travel-with-thymeleaf/ with 1 occurrences migrated to:  
  https://blog.springsource.org/2013/03/26/bringing-new-life-to-spring-travel-with-thymeleaf/ ([https](https://blog.springsource.org/2013/03/26/bringing-new-life-to-spring-travel-with-thymeleaf/) result 301).
* [ ] http://component.io/ with 1 occurrences migrated to:  
  https://component.io/ ([https](https://component.io/) result 301).
* [ ] http://dev.solace.com/tech/amqp/ with 1 occurrences migrated to:  
  https://dev.solace.com/tech/amqp/ ([https](https://dev.solace.com/tech/amqp/) result 301).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Autowired.html) result 301).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html) result 301).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContextAware.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContextAware.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/ApplicationContextAware.html) result 301).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html) result 301).
* [ ] http://en.wikipedia.org/wiki/WAR_file_format_ with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/WAR_file_format_ ([https](https://en.wikipedia.org/wiki/WAR_file_format_) result 301).
* [ ] http://mercurial.selenic.com/ with 1 occurrences migrated to:  
  https://mercurial.selenic.com/ ([https](https://mercurial.selenic.com/) result 301).
* [ ] http://npmjs.org/ with 1 occurrences migrated to:  
  https://npmjs.org/ ([https](https://npmjs.org/) result 301).
* [ ] http://rabbitmq.com with 1 occurrences migrated to:  
  https://rabbitmq.com ([https](https://rabbitmq.com) result 301).
* [ ] http://www.erlang.org/doc/man/mnesia.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/mnesia.html ([https](https://www.erlang.org/doc/man/mnesia.html) result 301).
* [ ] http://www.hazelcast.com/ with 1 occurrences migrated to:  
  https://www.hazelcast.com/ ([https](https://www.hazelcast.com/) result 301).
* [ ] http://www.mongodb.org/ with 1 occurrences migrated to:  
  https://www.mongodb.org/ ([https](https://www.mongodb.org/) result 301).
* [ ] http://www.neo4j.org/ with 1 occurrences migrated to:  
  https://www.neo4j.org/ ([https](https://www.neo4j.org/) result 301).
* [ ] http://www.springsource.org/spring-data/commons with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/commons ([https](https://www.springsource.org/spring-data/commons) result 301).
* [ ] http://www.springsource.org/spring-data/hadoop with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/hadoop ([https](https://www.springsource.org/spring-data/hadoop) result 301).
* [ ] http://www.springsource.org/spring-data/jdbc-extensions with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/jdbc-extensions ([https](https://www.springsource.org/spring-data/jdbc-extensions) result 301).
* [ ] http://www.springsource.org/spring-data/mongodb with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/mongodb ([https](https://www.springsource.org/spring-data/mongodb) result 301).
* [ ] http://www.springsource.org/spring-data/neo4j with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/neo4j ([https](https://www.springsource.org/spring-data/neo4j) result 301).
* [ ] http://www.springsource.org/spring-data/redis with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data/redis ([https](https://www.springsource.org/spring-data/redis) result 301).
* [ ] http://www.springsource.org/spring-gemfire with 2 occurrences migrated to:  
  https://www.springsource.org/spring-gemfire ([https](https://www.springsource.org/spring-gemfire) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/customer/1 with 1 occurrences
* http://localhost:8080/product/1 with 1 occurrences
* http://localhost:8080/product/3 with 1 occurrences
* http://localhost:8080/product/search with 1 occurrences