### PR TITLE
URL Cleanup

### DIFF
--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -2,7 +2,7 @@
 
 [Tomcat](http://tomcat.apache.org/) is an open source software implementation of the Java Servlet and JavaServer Pages (JSPs) technologies. Tomcat is flexible in that it allows third-party [view technologies][u-view-templates], hence it does not restrict you to JSPs.
 
-Tomcat is developed in an open and participatory environment that is governed by the [Apache Software Foundation](http://www.apache.org/). It is released under the [Apache License version 2](http://www.apache.org/licenses/LICENSE-2.0). 
+Tomcat is developed in an open and participatory environment that is governed by the [Apache Software Foundation](http://www.apache.org/). It is released under the [Apache License version 2](https://www.apache.org/licenses/LICENSE-2.0). 
 
 Tomcat powers numerous large-scale, mission-critical web applications across a diverse range of industries and organizations.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).